### PR TITLE
Add headers to prevent 403 errors

### DIFF
--- a/tdd/fetch_chains.py
+++ b/tdd/fetch_chains.py
@@ -115,7 +115,8 @@ class ChainFetcher:
         # Download and unbundle leaf certs
         uri = self._get_bundle_uri(ca_name)
         print(f"Downloading {uri}")
-        response = requests.get(uri)
+        headers = {'User-Agent': 'tdd'}
+        response = requests.get(uri, headers=headers)
         response.raise_for_status()
 
         cert_ders = self._unbundle_multipart(response.content)


### PR DESCRIPTION
FR05 dowload is failing if "User-Agent" is not defined in the header.